### PR TITLE
Add __stepname__ attribute to plugin __init__.

### DIFF
--- a/mapclientplugins/dicomsourcestep/__init__.py
+++ b/mapclientplugins/dicomsourcestep/__init__.py
@@ -4,6 +4,7 @@ MAP Client Plugin
 '''
 __version__ = '0.1.0'
 __author__ = 'Ju Zhang'
+__stepname__ = 'Dicom Source'
 
 
 # import class that derives itself from the step mountpoint.


### PR DESCRIPTION
This attribute is used by the MAP-Client to keep track of all the currently installed plugins, without it a number of MAP-Client plugin manager methods do not function correctly.